### PR TITLE
Down air can now stall in the air

### DIFF
--- a/src/ganon/acmd/aerials/attack_low_air.rs
+++ b/src/ganon/acmd/aerials/attack_low_air.rs
@@ -1,10 +1,23 @@
 //! D-Air can be cancelled on frame 30 instead of frame 32.
 use crate::imports::*;
+use crate::ganon::utils::*;
 
 const DAIR_LENGTH: f32 = 30.0;
 const DAIR_FRAME: f32 = 17.0;
 
 unsafe extern "C" fn ganon_attackairlw(agent: &mut L2CAgentBase) {
+    if macros::is_excute(agent) {
+        let boma = &mut *agent.module_accessor;
+
+        if !WorkModule::is_flag(agent.module_accessor, GANON_DOWN_AIR_STALL_FLAG)
+        && !boma.is_floating() {
+            WorkModule::on_flag(agent.module_accessor, GANON_DOWN_AIR_STALL_FLAG);
+
+            WorkModule::on_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_NO_SPEED_OPERATION_CHK);
+            macros::SET_SPEED_EX(agent, 0, 1.45, *KINETIC_ENERGY_RESERVE_ATTRIBUTE_MAIN);
+            WorkModule::off_flag(agent.module_accessor, *FIGHTER_INSTANCE_WORK_ID_FLAG_NO_SPEED_OPERATION_CHK);
+        }
+    }
     frame(agent.lua_state_agent, 4.0);
     if macros::is_excute(agent) {
         WorkModule::on_flag(

--- a/src/ganon/down_air_stall.rs
+++ b/src/ganon/down_air_stall.rs
@@ -1,0 +1,12 @@
+use crate::imports::*;
+use crate::ganon::utils::*;
+
+pub unsafe extern "C" fn down_air_stall(fighter: &mut L2CFighterCommon) {
+    let boma = &mut *fighter.module_accessor;
+
+    if boma.is_situation(*SITUATION_KIND_GROUND)
+    || boma.is_situation(*SITUATION_KIND_CLIFF)
+    || StopModule::is_damage(fighter.module_accessor) {
+        WorkModule::off_flag(fighter.module_accessor, GANON_DOWN_AIR_STALL_FLAG);
+    }
+}

--- a/src/ganon/frame.rs
+++ b/src/ganon/frame.rs
@@ -2,6 +2,7 @@ use super::utils::*;
 use crate::ganon::{
     down_tilt_followup::down_tilt_followup_input_checker, float::ganon_float,
     float_check::float_check, teleport_check::teleport_check, warlock_punch::warlock_punch,
+    down_air_stall::down_air_stall,
 };
 use crate::imports::*;
 
@@ -24,6 +25,7 @@ pub unsafe extern "C" fn ganon_frame(fighter: &mut L2CFighterCommon) {
     warlock_punch(fighter, &iv);
     teleport_check(fighter); // Removed InitValue
     down_tilt_followup_input_checker(fighter);
+    down_air_stall(fighter);
 }
 
 pub fn install() {

--- a/src/ganon/mod.rs
+++ b/src/ganon/mod.rs
@@ -1,5 +1,6 @@
 mod acmd;
 mod down_tilt_followup;
+mod down_air_stall;
 mod float;
 mod float_check;
 mod frame;

--- a/src/ganon/utils.rs
+++ b/src/ganon/utils.rs
@@ -126,6 +126,7 @@ pub static mut GS: [GanonState; 8] = [GanonState {
 pub const GANON_TELEPORT_WORK_INT: i32 = 0x42069;
 pub const GANON_FLOAT_DURATION_WORK_INT: i32 = 0x42070;
 pub const GANON_DOWN_SPECIAL_AIR_DURATION_FLAG: i32 = 0x69420;
+pub const GANON_DOWN_AIR_STALL_FLAG: i32 = 0x69421;
 pub const GANON_START_FLOAT_FLAG: i32 = 0x69423;
 pub const GANON_CAN_TELEPORT_FLAG: i32 = 0x69424;
 pub const GANON_PRE_FLOAT_MUTEX: i32 = 0x69425;
@@ -156,6 +157,7 @@ pub trait BomaExt {
     unsafe fn kinetic_kind(&mut self) -> i32;
 
     unsafe fn start_float(&mut self) -> bool;
+    unsafe fn is_floating(&mut self) -> bool;
 
     unsafe fn jump_button_pressed(&mut self) -> bool;
     // Or could do
@@ -205,6 +207,10 @@ impl BomaExt for BattleObjectModuleAccessor {
 
     unsafe fn start_float(&mut self) -> bool {
         WorkModule::is_flag(self, GANON_START_FLOAT_FLAG)
+    }
+
+    unsafe fn is_floating(&mut self) -> bool {
+        matches!(GS[self.entry_id()].float_status, FloatStatus::Floating(_))
     }
 
     unsafe fn jump_button_pressed(&mut self) -> bool {


### PR DESCRIPTION
Made it so that down air can stall in the air once. You are able to stall again if you land, grab ledge, or get hit.

Unfortunately, we need to run a check every frame. While there is a way to do it without doing that check, it's just easier this way.