### PR TITLE
Adjust cancel frames for up-tilt

### DIFF
--- a/src/ganon/acmd/ground/attack_up_tilt.rs
+++ b/src/ganon/acmd/ground/attack_up_tilt.rs
@@ -141,11 +141,6 @@ unsafe extern "C" fn ganon_utilt(fighter: &mut L2CAgentBase) {
     if macros::is_excute(fighter) {
         AttackModule::clear_all(fighter.module_accessor);
     }
-    frame(fighter.lua_state_agent, 26.0);
-    macros::FT_MOTION_RATE(fighter, /*FSM*/ 0.75);
-    if macros::is_excute(fighter) {
-        CancelModule::enable_cancel(fighter.module_accessor);
-    }
 }
 
 unsafe extern "C" fn ganon_utilt_eff(agent: &mut L2CAgentBase) {

--- a/src/ganon/status/mod.rs
+++ b/src/ganon/status/mod.rs
@@ -1,9 +1,11 @@
 mod backhand;
 mod teleport;
 mod down_special;
+mod up_tilt;
 
 pub fn install() {
     teleport::install();
     backhand::install();
     down_special::install();
+    up_tilt::install();
 }

--- a/src/ganon/status/up_tilt.rs
+++ b/src/ganon/status/up_tilt.rs
@@ -1,0 +1,27 @@
+use crate::imports::*;
+use crate::ganon::utils::*;
+
+unsafe extern "C" fn attackhi3_main(fighter: &mut L2CFighterCommon) -> L2CValue {
+    fighter.status_AttackHi3();
+
+    fighter.sub_shift_status_main(L2CValue::Ptr(attackhi3_main_loop as *const () as _))
+}
+
+unsafe extern "C" fn attackhi3_main_loop(fighter: &mut L2CFighterCommon) -> L2CValue {
+    let frame = MotionModule::frame(fighter.module_accessor);
+
+    if frame >= 26.0
+    && AttackModule::is_infliction_status(fighter.module_accessor, *COLLISION_KIND_MASK_HIT) {
+        CancelModule::enable_cancel(fighter.module_accessor);
+    }
+
+    fighter.status_AttackHi3_Main();
+
+    0.into()
+}
+
+pub fn install() {
+    Agent::new("ganon")
+        .status(Main, *FIGHTER_STATUS_KIND_ATTACK_HI3, attackhi3_main)
+        .install();
+}


### PR DESCRIPTION
Up tilt will now go through the entire animation if he doesn't hit anyone. If he does hit someone at any point during the move, he is able to act out early starting on frame 26.